### PR TITLE
Improve tasks page user experience

### DIFF
--- a/todo-ngrx/src/app/tasks/tasks-page.component.html
+++ b/todo-ngrx/src/app/tasks/tasks-page.component.html
@@ -1,41 +1,98 @@
-<section class="wrap">
+<section class="wrap tasks-page">
   <h1>Mes tâches</h1>
 
   <form class="card" [formGroup]="f" (ngSubmit)="add()">
     <div class="row">
-      <input placeholder="Titre *" formControlName="title" />
-      <select formControlName="priority">
-        <option [ngValue]="1">P1</option>
-        <option [ngValue]="2">P2</option>
-        <option [ngValue]="3">P3</option>
-        <option [ngValue]="4">P4</option>
-        <option [ngValue]="5">P5</option>
-      </select>
-      <input type="date" formControlName="dueDate" />
+      <div class="field-group">
+        <label for="title">Titre *</label>
+        <input id="title" placeholder="Ajouter un titre" formControlName="title" />
+        <p class="error" *ngIf="titleHasError">Le titre doit contenir au moins 2 caractères.</p>
+      </div>
+      <div class="field-group">
+        <label for="priority">Priorité</label>
+        <select id="priority" formControlName="priority">
+          <option [ngValue]="1">P1 - Critique</option>
+          <option [ngValue]="2">P2 - Haute</option>
+          <option [ngValue]="3">P3 - Normale</option>
+          <option [ngValue]="4">P4 - Basse</option>
+          <option [ngValue]="5">P5 - Très basse</option>
+        </select>
+      </div>
+      <div class="field-group">
+        <label for="dueDate">Échéance</label>
+        <input id="dueDate" type="date" formControlName="dueDate" />
+      </div>
     </div>
-    <textarea placeholder="Description" formControlName="description"></textarea>
-    <button type="submit" [disabled]="f.invalid">Ajouter</button>
+    <label class="field-group">
+      <span>Description</span>
+      <textarea placeholder="Détails (facultatif)" formControlName="description"></textarea>
+    </label>
+    <button type="submit" [disabled]="f.invalid">Ajouter la tâche</button>
   </form>
 
-  <div class="meta" *ngIf="counts$ | async as c">
-    {{ c.done }} / {{ c.total }} terminées
+  <div class="toolbar" *ngIf="counts$ | async as c">
+    <div class="meta" aria-live="polite">{{ c.done }} / {{ c.total }} terminées</div>
+    <button type="button" class="toggle-done" (click)="toggleDoneVisibility()">
+      {{ showDone ? 'Masquer les terminées' : 'Afficher les terminées' }}
+    </button>
   </div>
 
-  <h2>À faire</h2>
-  <ul class="list">
-    <li *ngFor="let t of (open$ | async)" [class.done]="t.completed">
-      <input type="checkbox" [checked]="t.completed" (change)="toggle(t.id)" />
-      <input class="title" [value]="t.title" (change)="upd(t.id, { title: $any($event.target).value })" />
-      <button class="del" (click)="del(t.id)">Supprimer</button>
-    </li>
-  </ul>
+  <section class="list-section">
+    <header>
+      <h2>À faire</h2>
+    </header>
+    <ng-container *ngIf="(open$ | async) as open">
+      <div class="empty-state" *ngIf="open.length === 0">
+        Vous êtes à jour, aucune tâche en cours.
+      </div>
+      <ul class="list" *ngIf="open.length > 0">
+        <li *ngFor="let t of open; trackBy: trackByTaskId" [class.done]="t.completed">
+          <input type="checkbox" [checked]="t.completed" (change)="toggle(t.id)" [attr.aria-label]="'Marquer ' + t.title + ' comme terminée'" />
+          <div class="content">
+            <input class="title editable" [value]="t.title" (change)="upd(t.id, { title: $any($event.target).value })" />
+            <div class="meta-line">
+              <span class="badge priority" [ngClass]="'p' + t.priority">{{ priorityLabel(t.priority) }}</span>
+              <span class="badge due" *ngIf="t.dueDate" [ngClass]="dueClass(t.dueDate)">
+                {{ dueLabel(t.dueDate) }}
+              </span>
+            </div>
+            <p class="desc" *ngIf="t.description">{{ t.description }}</p>
+          </div>
+          <button class="del" (click)="del(t.id)" [attr.aria-label]="'Supprimer ' + t.title">Supprimer</button>
+        </li>
+      </ul>
+    </ng-container>
+  </section>
 
-  <h2>Terminées</h2>
-  <ul class="list">
-    <li *ngFor="let t of (done$ | async)" class="done">
-      <input type="checkbox" [checked]="true" (change)="toggle(t.id)" />
-      <span class="title">{{ t.title }}</span>
-      <button class="del" (click)="del(t.id)">Supprimer</button>
-    </li>
-  </ul>
+  <section class="list-section" *ngIf="showDone">
+    <header>
+      <h2>Terminées</h2>
+    </header>
+    <ng-container *ngIf="(done$ | async) as done">
+      <div class="empty-state" *ngIf="done.length === 0">
+        Aucune tâche terminée pour le moment.
+      </div>
+      <ul class="list" *ngIf="done.length > 0">
+        <li *ngFor="let t of done; trackBy: trackByTaskId" class="done">
+          <input
+            type="checkbox"
+            [checked]="true"
+            (change)="toggle(t.id)"
+            [attr.aria-label]="'Réactiver ' + t.title"
+          />
+          <div class="content">
+            <span class="title">{{ t.title }}</span>
+            <div class="meta-line">
+              <span class="badge priority" [ngClass]="'p' + t.priority">{{ priorityLabel(t.priority) }}</span>
+              <span class="badge due" *ngIf="t.dueDate" [ngClass]="dueClass(t.dueDate)">
+                {{ dueLabel(t.dueDate) }}
+              </span>
+            </div>
+            <p class="desc" *ngIf="t.description">{{ t.description }}</p>
+          </div>
+          <button class="del" (click)="del(t.id)" [attr.aria-label]="'Supprimer ' + t.title">Supprimer</button>
+        </li>
+      </ul>
+    </ng-container>
+  </section>
 </section>

--- a/todo-ngrx/src/app/tasks/tasks-page.component.scss
+++ b/todo-ngrx/src/app/tasks/tasks-page.component.scss
@@ -1,29 +1,49 @@
-.wrap { max-width: 900px; margin: 24px auto; padding: 0 16px; }
+.wrap { max-width: 900px; margin: 24px auto; padding: 0 16px 48px; }
 
 .card {
   border: 1px solid #e5e7eb;
   padding: 16px;
   border-radius: 12px;
   display: grid;
-  gap: 8px;
+  gap: 16px;
   background: #fff;
+  box-shadow: 0 10px 25px rgba(15, 23, 42, 0.05);
 }
 
 .row {
   display: grid;
-  grid-template-columns: 1fr 100px 160px;
-  gap: 8px;
+  grid-template-columns: 1.5fr 1fr 1fr;
+  gap: 16px;
+  flex-wrap: wrap;
 }
+
+.field-group {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 0.9rem;
+}
+
+label { font-weight: 600; color: #374151; }
 
 input, select, textarea, button {
   border: 1px solid #e5e7eb;
   border-radius: 8px;
-  padding: 8px;
+  padding: 10px 12px;
+  font-size: 0.95rem;
 }
 
-textarea { min-height: 70px; }
+textarea { min-height: 90px; resize: vertical; }
 
-.meta { color: #6b7280; font-size: .9rem; margin: 12px 0; }
+.error {
+  color: #b91c1c;
+  margin: 0;
+  font-size: 0.85rem;
+}
+
+.meta { color: #6b7280; font-size: .9rem; }
+
+.list-section + .list-section { margin-top: 32px; }
 
 h2 { margin-top: 16px; font-size: 1.1rem; }
 
@@ -31,15 +51,32 @@ h2 { margin-top: 16px; font-size: 1.1rem; }
 
 .list li {
   display: grid;
-  grid-template-columns: 22px 1fr 110px;
-  gap: 8px;
-  align-items: center;
-  padding: 8px 0;
-  border-bottom: 1px dashed #eee;
+  grid-template-columns: 24px 1fr auto;
+  gap: 12px;
+  align-items: flex-start;
+  padding: 16px 0;
+  border-bottom: 1px dashed #e5e7eb;
 }
 
-.list li .title { width: 100%; }
+.list li:last-child { border-bottom: none; }
+
+.list li .title { width: 100%; font-weight: 600; font-size: 1rem; }
+
+.list li .title.editable {
+  border: none;
+  background: #f9fafb;
+  padding: 8px 12px;
+}
+
+.list li .title.editable:focus {
+  outline: 2px solid #6366f1;
+  background: #fff;
+}
 
 .list li.done .title { text-decoration: line-through; opacity: .7; }
 
-button.del { background: #fee2e2; border-color: #fecaca; }
+@media (max-width: 768px) {
+  .row { grid-template-columns: 1fr; }
+  .list li { grid-template-columns: 24px 1fr; }
+  .list li .del { justify-self: flex-end; }
+}

--- a/todo-ngrx/src/app/tasks/tasks-page.component.ts
+++ b/todo-ngrx/src/app/tasks/tasks-page.component.ts
@@ -13,6 +13,10 @@ import { selectOpenTasks, selectDoneTasks, selectCounts } from './state/tasks.se
   styleUrls: ['./tasks-page.component.scss'],
 })
 export class TasksPageComponent {
+  private readonly dateFormatter = new Intl.DateTimeFormat('fr-FR', { dateStyle: 'long' });
+  private submitted = false;
+  showDone = true;
+
   f = this.fb.group({
     title: ['', [Validators.required, Validators.minLength(2), Validators.maxLength(160)]],
     description: [''],
@@ -27,6 +31,8 @@ export class TasksPageComponent {
   constructor(private fb: FormBuilder, private store: Store) {}
 
   add() {
+    this.submitted = true;
+    this.f.markAllAsTouched();
     if (this.f.invalid) return;
     const { title, description, priority, dueDate } = this.f.value;
     this.store.dispatch(A.addTask({
@@ -34,9 +40,66 @@ export class TasksPageComponent {
       priority: (priority as any) ?? 3, dueDate: dueDate || undefined
     }));
     this.f.reset({ title: '', description: '', priority: 3, dueDate: '' });
+    this.submitted = false;
   }
 
   toggle(id: string) { this.store.dispatch(A.toggleComplete({ id })); }
   del(id: string)    { this.store.dispatch(A.removeTask({ id })); }
   upd(id: string, changes: any) { this.store.dispatch(A.updateTask({ id, changes })); }
+
+  toggleDoneVisibility() { this.showDone = !this.showDone; }
+
+  trackByTaskId(_: number, task: { id: string }) { return task.id; }
+
+  get titleHasError() {
+    const ctrl = this.f.get('title');
+    if (!ctrl) return false;
+    return (ctrl.touched || this.submitted) && ctrl.invalid;
+  }
+
+  priorityLabel(priority: number | null | undefined) {
+    const labels: Record<number, string> = {
+      1: 'P1 · Critique',
+      2: 'P2 · Haute',
+      3: 'P3 · Normale',
+      4: 'P4 · Basse',
+      5: 'P5 · Très basse',
+    };
+    return labels[priority ?? 3] ?? labels[3];
+  }
+
+  dueLabel(dueDate?: string | null) {
+    const days = this.daysUntil(dueDate);
+    if (days === undefined) return '';
+    const date = new Date(dueDate!);
+    const formatted = this.dateFormatter.format(date);
+    let relative: string;
+    if (days === 0) relative = "aujourd’hui";
+    else if (days === 1) relative = 'demain';
+    else if (days > 1) relative = `dans ${days} jours`;
+    else if (days === -1) relative = 'hier';
+    else relative = `il y a ${Math.abs(days)} jours`;
+    return `${formatted} · ${relative}`;
+  }
+
+  dueClass(dueDate?: string | null) {
+    const days = this.daysUntil(dueDate);
+    if (days === undefined) return '';
+    if (days < 0) return 'overdue';
+    if (days === 0) return 'due-today';
+    if (days <= 3) return 'due-soon';
+    return 'due-later';
+  }
+
+  private daysUntil(dueDate?: string | null) {
+    if (!dueDate) return undefined;
+    const due = new Date(dueDate);
+    if (Number.isNaN(due.getTime())) return undefined;
+    const today = new Date();
+    const startOf = (d: Date) => { const nd = new Date(d); nd.setHours(0,0,0,0); return nd; };
+    const dueStart = startOf(due).getTime();
+    const todayStart = startOf(today).getTime();
+    const diff = Math.round((dueStart - todayStart) / 86400000);
+    return diff;
+  }
 }

--- a/todo-ngrx/src/styles.scss
+++ b/todo-ngrx/src/styles.scss
@@ -1,1 +1,111 @@
 /* You can add global styles to this file, and also import other style files */
+
+:root {
+  color-scheme: light;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+body {
+  margin: 0;
+  background: #f3f4f6;
+  color: #111827;
+}
+
+button {
+  background: #111827;
+  color: #fff;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  cursor: pointer;
+  font-weight: 600;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
+  padding: 10px 16px;
+}
+
+button:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 24px rgba(17, 24, 39, 0.18);
+}
+
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+  box-shadow: none;
+}
+
+.tasks-page .toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+  margin: 24px 0;
+  flex-wrap: wrap;
+}
+
+.tasks-page .toggle-done {
+  background: #eef2ff;
+  color: #4338ca;
+  border-color: #c7d2fe;
+}
+
+.tasks-page .content {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.tasks-page .meta-line {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  font-size: 0.85rem;
+  color: #4b5563;
+}
+
+.tasks-page .badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  border-radius: 999px;
+  padding: 2px 10px;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.tasks-page .badge.priority.p1 { background: #fee2e2; color: #b91c1c; }
+.tasks-page .badge.priority.p2 { background: #fef3c7; color: #b45309; }
+.tasks-page .badge.priority.p3 { background: #dcfce7; color: #166534; }
+.tasks-page .badge.priority.p4 { background: #e0f2fe; color: #0c4a6e; }
+.tasks-page .badge.priority.p5 { background: #ede9fe; color: #5b21b6; }
+
+.tasks-page .badge.due { background: #e5e7eb; color: #374151; }
+.tasks-page .badge.due.overdue { background: #fee2e2; color: #b91c1c; }
+.tasks-page .badge.due.due-today { background: #fef3c7; color: #92400e; }
+.tasks-page .badge.due.due-soon { background: #dbeafe; color: #1d4ed8; }
+
+.tasks-page .desc {
+  margin: 0;
+  color: #4b5563;
+  font-size: 0.9rem;
+}
+
+.tasks-page .empty-state {
+  border: 1px dashed #d1d5db;
+  border-radius: 12px;
+  padding: 24px;
+  text-align: center;
+  color: #6b7280;
+  background: #f9fafb;
+  font-size: 0.95rem;
+}
+
+.tasks-page button.del {
+  background: #fee2e2;
+  border-color: #fecaca;
+  color: #991b1b;
+  padding: 8px 12px;
+}
+
+@media (max-width: 768px) {
+  .tasks-page .toolbar { flex-direction: column; align-items: stretch; }
+}


### PR DESCRIPTION
## Summary
- add inline validation and visibility controls to the tasks page form and lists
- highlight task priority and due dates with badges and contextual messaging
- promote shared button and layout styles to the global stylesheet for a cohesive theme

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68db95e30df88324ac83abdfd824c9db