### PR TITLE
Order tasks by due date and priority

### DIFF
--- a/todo-ngrx/src/app/tasks/state/tasks.reducer.ts
+++ b/todo-ngrx/src/app/tasks/state/tasks.reducer.ts
@@ -4,9 +4,25 @@ import * as A from './tasks.actions';
 import { Task, newId } from './tasks.models';
 
 export type TasksState = EntityState<Task>;
+const dueDateValue = (dueDate?: string) => {
+  if (!dueDate) return Number.POSITIVE_INFINITY;
+  const time = new Date(dueDate).getTime();
+  return Number.isNaN(time) ? Number.POSITIVE_INFINITY : time;
+};
+
+const compareTasks = (a: Task, b: Task) => {
+  const dueA = dueDateValue(a.dueDate);
+  const dueB = dueDateValue(b.dueDate);
+  if (dueA !== dueB) return dueA < dueB ? -1 : 1;
+
+  if (a.priority !== b.priority) return a.priority - b.priority;
+
+  return a.createdAt.localeCompare(b.createdAt);
+};
+
 const adapter = createEntityAdapter<Task>({
   selectId: t => t.id,
-  sortComparer: (a,b) => a.createdAt.localeCompare(b.createdAt),
+  sortComparer: compareTasks,
 });
 const initialState: TasksState = adapter.getInitialState();
 


### PR DESCRIPTION
## Summary
- order task entity adapter results by earliest due dates first
- break ties using task priority and creation time to keep ordering stable

## Testing
- npm test -- --watch=false *(fails: Chrome browser binary not available in CI environment)*

------
https://chatgpt.com/codex/tasks/task_b_68db9967d38c8324ad13ce1e2d370cd1