### PR TITLE
feat: refresh application styling

### DIFF
--- a/todo-ngrx/src/app/app.component.scss
+++ b/todo-ngrx/src/app/app.component.scss
@@ -1,5 +1,32 @@
+:host {
+  display: block;
+  min-height: 100vh;
+  padding: clamp(16px, 4vw, 32px) 0 64px;
+}
+
 .container {
-  max-width: 900px;
-  margin: 24px auto;
-  padding: 0 16px;
+  width: min(960px, calc(100% - clamp(32px, 6vw, 80px)));
+  margin: 0 auto;
+  padding: clamp(24px, 5vw, 48px);
+  background: var(--surface);
+  border-radius: 28px;
+  border: 1px solid var(--border-soft);
+  box-shadow: var(--shadow-lg);
+  backdrop-filter: blur(12px);
+  position: relative;
+  overflow: hidden;
+}
+
+.container::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at top right, rgba(99, 102, 241, 0.18), transparent 55%);
+  pointer-events: none;
+  opacity: 0.75;
+}
+
+.container > * {
+  position: relative;
+  z-index: 1;
 }

--- a/todo-ngrx/src/app/auth/login/login.component.scss
+++ b/todo-ngrx/src/app/auth/login/login.component.scss
@@ -1,115 +1,69 @@
-
 :host {
-  display: block;
-  min-height: calc(100dvh - 64px); 
-  background: var(--bg);
-  color: var(--text);
-}
-
-:root {
-  --bg: #f6f7fb;
-  --card: #ffffff;
-  --text: #111827;
-  --muted: #6b7280;
-  --border: #e5e7eb;
-  --primary: #2563eb;
-  --primary-press: #1e40af;
-  --ring: #93c5fd;
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --bg: #0b1020;
-    --card: #0f172a;
-    --text: #e5e7eb;
-    --muted: #94a3b8;
-    --border: #1f2937;
-    --primary: #60a5fa;
-    --primary-press: #3b82f6;
-    --ring: #2563eb;
-  }
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: clamp(420px, 60vh, 520px);
 }
 
 section.card {
-  max-width: 420px;
-  margin: clamp(24px, 8vh, 80px) auto;
-  background: var(--card);
-  border: 1px solid var(--border);
-  border-radius: 16px;
-  padding: 24px;
-  box-shadow: 0 10px 30px rgba(0,0,0,.06);
+  width: min(420px, 100%);
+  margin: 0 auto;
+  background: var(--surface-strong);
+  border: 1px solid var(--border-soft);
+  border-radius: 24px;
+  padding: clamp(24px, 5vw, 36px);
+  box-shadow: var(--shadow-sm);
+  backdrop-filter: blur(10px);
+  display: grid;
+  gap: 20px;
 }
 
 h1 {
-  font-size: 1.5rem;
-  margin: 0 0 16px;
+  font-size: clamp(1.6rem, 3vw, 2rem);
+  margin: 0;
 }
 
 form {
   display: grid;
-  gap: 12px;
+  gap: 16px;
 }
 
 label {
-  font-size: .9rem;
-  color: var(--muted);
+  font-size: 0.9rem;
+  color: var(--text-muted);
 }
 
-input[type="email"] {
+input[type='email'] {
   width: 100%;
-  padding: 10px 12px;
-  border: 1px solid var(--border);
-  border-radius: 10px;
-  background: transparent;
-  color: inherit;
-  transition: border-color .15s ease, box-shadow .15s ease;
 }
 
-input::placeholder { color: var(--muted); }
+input::placeholder {
+  color: color-mix(in srgb, var(--text-muted) 80%, white 20%);
+}
 
 input:focus-visible {
-  outline: none;
-  border-color: var(--primary);
-  box-shadow: 0 0 0 3px color-mix(in srgb, var(--ring) 40%, transparent);
-}
-
-.ng-invalid.ng-touched input,
-input.ng-invalid.ng-touched {
-  border-color: #ef4444;
+  border-color: var(--brand);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--brand) 28%, transparent);
 }
 
 .error {
-  color: #ef4444;
-  font-size: .8rem;
+  color: var(--danger);
+  font-size: 0.8rem;
 }
 
 .hint {
-  margin-top: 6px;
-  font-size: .8rem;
-  color: var(--muted);
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--text-muted);
 }
 
-button[type="submit"] {
-  appearance: none;
-  border: 0;
-  border-radius: 10px;
-  padding: 10px 14px;
-  background: var(--primary);
-  color: white;
-  font-weight: 600;
-  cursor: pointer;
-  transition: transform .06s ease, background .15s ease;
+button[type='submit'] {
+  border: none;
+  border-radius: 999px;
+  padding: 12px 18px;
 }
 
 button[disabled] {
-  opacity: .6;
+  opacity: 0.6;
   cursor: not-allowed;
-}
-
-button:active { transform: translateY(1px); }
-button:not([disabled]):hover { background: var(--primary-press); }
-
-/* petit utilitaire pour centrer quand pas de header */
-:host-context(body:not(.with-header)) section.card {
-  min-height: 0;
 }

--- a/todo-ngrx/src/app/core/header/header.component.html
+++ b/todo-ngrx/src/app/core/header/header.component.html
@@ -1,5 +1,5 @@
 <header class="hdr">
-  <a class="logo" routerLink="/">ToDo NgRx</a>
+  <a class="logo" routerLink="/">ToDo <span>NgRx</span></a>
   <div class="spacer"></div>
   <ng-container *ngIf="isAuthed$ | async; else guest">
     <span class="email">{{ email$ | async }}</span>

--- a/todo-ngrx/src/app/core/header/header.component.scss
+++ b/todo-ngrx/src/app/core/header/header.component.scss
@@ -1,11 +1,66 @@
-.hdr {
-  display: flex; align-items: center;
-  padding: 10px 16px; border-bottom: 1px solid #eee; background: #fff;
+:host {
+  display: block;
+  padding: clamp(16px, 4vw, 32px) 0 0;
 }
-.logo { font-weight: 600; text-decoration: none; color: inherit; }
-.spacer { flex: 1; }
-.email { margin-right: 12px; color: #555; }
+
+.hdr {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  width: min(960px, calc(100% - clamp(32px, 6vw, 80px)));
+  margin: 0 auto;
+  padding: 18px clamp(20px, 5vw, 32px);
+  border-radius: 24px;
+  border: 1px solid color-mix(in srgb, var(--border-soft) 70%, transparent);
+  background: color-mix(in srgb, var(--surface) 85%, rgba(255, 255, 255, 0.7) 15%);
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.12);
+  backdrop-filter: blur(18px);
+}
+
+.logo {
+  font-weight: 700;
+  font-size: 1.1rem;
+  letter-spacing: -0.01em;
+  text-decoration: none;
+  color: var(--text-strong);
+}
+
+.logo span {
+  color: var(--brand-strong);
+}
+
+.spacer {
+  flex: 1;
+}
+
+.email {
+  margin-right: 12px;
+  color: var(--text-muted);
+  font-size: 0.95rem;
+}
+
 button {
-  padding: 6px 10px; border: 0; border-radius: 8px;
-  background: #efefef; cursor: pointer;
+  padding: 8px 18px;
+  border: none;
+  border-radius: 999px;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0.1));
+  color: var(--text-strong);
+  font-weight: 600;
+  box-shadow: none;
+}
+
+button:hover:not(:disabled) {
+  filter: brightness(1.02);
+}
+
+@media (max-width: 640px) {
+  .hdr {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 12px;
+  }
+
+  .email {
+    margin: 0;
+  }
 }

--- a/todo-ngrx/src/app/tasks/tasks-page.component.scss
+++ b/todo-ngrx/src/app/tasks/tasks-page.component.scss
@@ -1,20 +1,33 @@
-.wrap { max-width: 900px; margin: 24px auto; padding: 0 16px 48px; }
+:host {
+  display: block;
+}
+
+.wrap {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(24px, 4vw, 40px);
+}
+
+h1 {
+  font-size: clamp(1.8rem, 2.5vw, 2.25rem);
+  margin: 0;
+}
 
 .card {
-  border: 1px solid #e5e7eb;
-  padding: 16px;
-  border-radius: 12px;
+  border: 1px solid var(--border-soft);
+  padding: clamp(20px, 4vw, 32px);
+  border-radius: 24px;
   display: grid;
-  gap: 16px;
-  background: #fff;
-  box-shadow: 0 10px 25px rgba(15, 23, 42, 0.05);
+  gap: 20px;
+  background: var(--surface-strong);
+  box-shadow: var(--shadow-sm);
+  backdrop-filter: blur(8px);
 }
 
 .row {
   display: grid;
   grid-template-columns: 1.5fr 1fr 1fr;
   gap: 16px;
-  flex-wrap: wrap;
 }
 
 .field-group {
@@ -24,59 +37,127 @@
   font-size: 0.9rem;
 }
 
-label { font-weight: 600; color: #374151; }
-
-input, select, textarea, button {
-  border: 1px solid #e5e7eb;
-  border-radius: 8px;
-  padding: 10px 12px;
-  font-size: 0.95rem;
+label {
+  font-weight: 600;
+  color: var(--text-muted);
 }
 
-textarea { min-height: 90px; resize: vertical; }
+textarea {
+  min-height: 90px;
+}
 
 .error {
-  color: #b91c1c;
+  color: var(--danger);
   margin: 0;
   font-size: 0.85rem;
 }
 
-.meta { color: #6b7280; font-size: .9rem; }
+.meta {
+  color: var(--text-muted);
+  font-size: 0.95rem;
+  background: rgba(255, 255, 255, 0.45);
+  padding: 8px 14px;
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, var(--border-soft) 70%, transparent);
+}
 
-.list-section + .list-section { margin-top: 32px; }
+.list-section {
+  display: grid;
+  gap: 16px;
+}
 
-h2 { margin-top: 16px; font-size: 1.1rem; }
+.list-section > header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
 
-.list { list-style: none; padding: 0; margin: 8px 0; }
+.list-section > header h2 {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 14px;
+}
 
 .list li {
   display: grid;
-  grid-template-columns: 24px 1fr auto;
-  gap: 12px;
+  grid-template-columns: auto 1fr auto;
+  gap: 16px;
   align-items: flex-start;
-  padding: 16px 0;
-  border-bottom: 1px dashed #e5e7eb;
+  padding: 18px clamp(16px, 4vw, 24px);
+  border-radius: 20px;
+  border: 1px solid var(--border-soft);
+  background: color-mix(in srgb, var(--surface) 80%, rgba(255, 255, 255, 0.9) 20%);
+  box-shadow: 0 18px 40px -24px rgba(15, 23, 42, 0.35);
+  transition: transform 0.15s ease, box-shadow 0.15s ease, border 0.15s ease;
 }
 
-.list li:last-child { border-bottom: none; }
+.list li:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 24px 50px -28px rgba(15, 23, 42, 0.4);
+  border-color: color-mix(in srgb, var(--border-soft) 60%, transparent);
+}
 
-.list li .title { width: 100%; font-weight: 600; font-size: 1rem; }
+.list li input[type='checkbox'] {
+  width: 22px;
+  height: 22px;
+  margin-top: 4px;
+  accent-color: var(--brand);
+}
+
+.list li .title {
+  width: 100%;
+  font-weight: 600;
+  font-size: 1.05rem;
+  color: var(--text-strong);
+}
 
 .list li .title.editable {
   border: none;
-  background: #f9fafb;
-  padding: 8px 12px;
+  background: rgba(255, 255, 255, 0.55);
+  padding: 10px 12px;
+  border-radius: 12px;
+  transition: box-shadow 0.15s ease, background 0.15s ease;
 }
 
 .list li .title.editable:focus {
-  outline: 2px solid #6366f1;
+  outline: none;
   background: #fff;
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--brand) 28%, transparent);
 }
 
-.list li.done .title { text-decoration: line-through; opacity: .7; }
+.list li.done {
+  opacity: 0.75;
+  background: color-mix(in srgb, rgba(226, 232, 240, 0.45) 60%, transparent);
+}
+
+.list li.done .title {
+  text-decoration: line-through;
+}
+
+.list li .del {
+  align-self: center;
+}
+
+@media (max-width: 900px) {
+  .row {
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  }
+}
 
 @media (max-width: 768px) {
-  .row { grid-template-columns: 1fr; }
-  .list li { grid-template-columns: 24px 1fr; }
-  .list li .del { justify-self: flex-end; }
+  .list li {
+    grid-template-columns: auto 1fr;
+  }
+
+  .list li .del {
+    justify-self: flex-end;
+  }
 }

--- a/todo-ngrx/src/styles.scss
+++ b/todo-ngrx/src/styles.scss
@@ -1,38 +1,124 @@
-/* You can add global styles to this file, and also import other style files */
-
+/* Global design refresh */
 :root {
   color-scheme: light;
   font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --gradient-1: #eef2ff;
+  --gradient-2: #fce7f3;
+  --gradient-3: #e0f2fe;
+  --surface: rgba(255, 255, 255, 0.9);
+  --surface-strong: rgba(255, 255, 255, 0.97);
+  --border-soft: rgba(148, 163, 184, 0.35);
+  --border-strong: rgba(148, 163, 184, 0.55);
+  --text-strong: #0f172a;
+  --text-muted: #64748b;
+  --brand: #6366f1;
+  --brand-strong: #4338ca;
+  --brand-soft: rgba(99, 102, 241, 0.14);
+  --danger: #ef4444;
+  --success: #16a34a;
+  --shadow-sm: 0 18px 45px rgba(15, 23, 42, 0.12);
+  --shadow-lg: 0 32px 80px -40px rgba(15, 23, 42, 0.4);
+}
+
+*, *::before, *::after {
+  box-sizing: border-box;
 }
 
 body {
   margin: 0;
-  background: #f3f4f6;
-  color: #111827;
+  min-height: 100vh;
+  background:
+    radial-gradient(circle at 20% 20%, rgba(99, 102, 241, 0.16), transparent 55%),
+    radial-gradient(circle at 82% 16%, rgba(14, 165, 233, 0.18), transparent 52%),
+    linear-gradient(135deg, var(--gradient-1), var(--gradient-2) 48%, var(--gradient-3));
+  background-attachment: fixed;
+  color: var(--text-strong);
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+  transition: color 0.15s ease;
+}
+
+a:hover {
+  color: var(--brand-strong);
+}
+
+h1, h2, h3 {
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--text-strong);
+}
+
+p {
+  color: var(--text-muted);
+  line-height: 1.6;
 }
 
 button {
-  background: #111827;
+  background: linear-gradient(135deg, var(--brand), var(--brand-strong));
   color: #fff;
   border: 1px solid transparent;
-  border-radius: 8px;
+  border-radius: 999px;
   cursor: pointer;
   font-weight: 600;
-  transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
-  padding: 10px 16px;
+  font-size: 0.95rem;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease;
+  padding: 10px 20px;
+  box-shadow: var(--shadow-sm);
 }
 
 button:hover:not(:disabled) {
   transform: translateY(-1px);
-  box-shadow: 0 10px 24px rgba(17, 24, 39, 0.18);
+  filter: brightness(1.05);
+}
+
+button:active:not(:disabled) {
+  transform: translateY(0);
 }
 
 button:disabled {
   cursor: not-allowed;
-  opacity: 0.55;
+  opacity: 0.6;
   box-shadow: none;
 }
 
+button:focus-visible {
+  outline: 3px solid color-mix(in srgb, var(--brand) 45%, transparent);
+  outline-offset: 2px;
+}
+
+input,
+select,
+textarea {
+  border: 1px solid var(--border-soft);
+  border-radius: 12px;
+  padding: 12px 14px;
+  font-size: 0.95rem;
+  background: var(--surface);
+  color: var(--text-strong);
+  transition: border 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
+}
+
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible {
+  outline: none;
+  border-color: var(--brand);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--brand) 30%, transparent);
+  background: var(--surface-strong);
+}
+
+textarea {
+  resize: vertical;
+}
+
+::selection {
+  background: color-mix(in srgb, var(--brand) 20%, white);
+}
+
+/* Tasks specific helpers */
 .tasks-page .toolbar {
   display: flex;
   justify-content: space-between;
@@ -43,9 +129,13 @@ button:disabled {
 }
 
 .tasks-page .toggle-done {
-  background: #eef2ff;
-  color: #4338ca;
-  border-color: #c7d2fe;
+  background: var(--brand-soft);
+  color: var(--brand-strong);
+  box-shadow: none;
+}
+
+.tasks-page .toggle-done:hover {
+  filter: brightness(1.05);
 }
 
 .tasks-page .content {
@@ -59,7 +149,7 @@ button:disabled {
   gap: 8px;
   flex-wrap: wrap;
   font-size: 0.85rem;
-  color: #4b5563;
+  color: var(--text-muted);
 }
 
 .tasks-page .badge {
@@ -67,45 +157,54 @@ button:disabled {
   align-items: center;
   gap: 4px;
   border-radius: 999px;
-  padding: 2px 10px;
+  padding: 4px 10px;
   font-size: 0.75rem;
   font-weight: 600;
+  background: rgba(15, 23, 42, 0.05);
 }
 
-.tasks-page .badge.priority.p1 { background: #fee2e2; color: #b91c1c; }
-.tasks-page .badge.priority.p2 { background: #fef3c7; color: #b45309; }
-.tasks-page .badge.priority.p3 { background: #dcfce7; color: #166534; }
-.tasks-page .badge.priority.p4 { background: #e0f2fe; color: #0c4a6e; }
-.tasks-page .badge.priority.p5 { background: #ede9fe; color: #5b21b6; }
+.tasks-page .badge.priority.p1 { background: rgba(239, 68, 68, 0.15); color: #b91c1c; }
+.tasks-page .badge.priority.p2 { background: rgba(249, 115, 22, 0.15); color: #b45309; }
+.tasks-page .badge.priority.p3 { background: rgba(34, 197, 94, 0.18); color: #166534; }
+.tasks-page .badge.priority.p4 { background: rgba(59, 130, 246, 0.16); color: #0c4a6e; }
+.tasks-page .badge.priority.p5 { background: rgba(139, 92, 246, 0.18); color: #5b21b6; }
 
-.tasks-page .badge.due { background: #e5e7eb; color: #374151; }
-.tasks-page .badge.due.overdue { background: #fee2e2; color: #b91c1c; }
-.tasks-page .badge.due.due-today { background: #fef3c7; color: #92400e; }
-.tasks-page .badge.due.due-soon { background: #dbeafe; color: #1d4ed8; }
+.tasks-page .badge.due { background: rgba(15, 23, 42, 0.08); color: #1f2937; }
+.tasks-page .badge.due.overdue { background: rgba(239, 68, 68, 0.16); color: #b91c1c; }
+.tasks-page .badge.due.due-today { background: rgba(249, 115, 22, 0.16); color: #92400e; }
+.tasks-page .badge.due.due-soon { background: rgba(59, 130, 246, 0.16); color: #1d4ed8; }
 
 .tasks-page .desc {
   margin: 0;
-  color: #4b5563;
+  color: var(--text-muted);
   font-size: 0.9rem;
 }
 
 .tasks-page .empty-state {
-  border: 1px dashed #d1d5db;
-  border-radius: 12px;
-  padding: 24px;
+  border: 1px dashed var(--border-soft);
+  border-radius: 16px;
+  padding: 32px;
   text-align: center;
-  color: #6b7280;
-  background: #f9fafb;
+  color: var(--text-muted);
+  background: var(--surface);
   font-size: 0.95rem;
 }
 
 .tasks-page button.del {
-  background: #fee2e2;
-  border-color: #fecaca;
+  background: rgba(239, 68, 68, 0.12);
+  border-color: rgba(248, 113, 113, 0.4);
   color: #991b1b;
-  padding: 8px 12px;
+  padding: 10px 16px;
+  box-shadow: none;
+}
+
+.tasks-page button.del:hover {
+  filter: brightness(0.98);
 }
 
 @media (max-width: 768px) {
-  .tasks-page .toolbar { flex-direction: column; align-items: stretch; }
+  .tasks-page .toolbar {
+    flex-direction: column;
+    align-items: stretch;
+  }
 }


### PR DESCRIPTION
## Summary
- Refresh the global palette with gradients, reusable color tokens, and updated control styles for a softer interface.
- Polish the main container and header with glassmorphism-inspired panels and responsive spacing.
- Redesign the task list and login card to use elevated cards, richer typography, and consistent badges.

## Testing
- npm run lint *(fails: script missing)*


------
https://chatgpt.com/codex/tasks/task_b_68db9a81a7c48324938b325ca068bd7b