### PR TITLE
Enable inline editing for task details

### DIFF
--- a/todo-ngrx/src/app/tasks/tasks-page.component.html
+++ b/todo-ngrx/src/app/tasks/tasks-page.component.html
@@ -49,14 +49,44 @@
         <li *ngFor="let t of open; trackBy: trackByTaskId" [class.done]="t.completed">
           <input type="checkbox" [checked]="t.completed" (change)="toggle(t.id)" [attr.aria-label]="'Marquer ' + t.title + ' comme terminée'" />
           <div class="content">
-            <input class="title editable" [value]="t.title" (change)="upd(t.id, { title: $any($event.target).value })" />
-            <div class="meta-line">
-              <span class="badge priority" [ngClass]="'p' + t.priority">{{ priorityLabel(t.priority) }}</span>
-              <span class="badge due" *ngIf="t.dueDate" [ngClass]="dueClass(t.dueDate)">
-                {{ dueLabel(t.dueDate) }}
-              </span>
+            <input
+              class="title editable editor-input"
+              [value]="t.title"
+              (change)="upd(t.id, { title: $any($event.target).value })"
+            />
+            <div class="meta-line editors">
+              <div class="priority-editor">
+                <select
+                  class="editor-input priority-select"
+                  [value]="t.priority"
+                  (change)="changePriority(t.id, $event)"
+                >
+                  <option [ngValue]="1">P1 - Critique</option>
+                  <option [ngValue]="2">P2 - Haute</option>
+                  <option [ngValue]="3">P3 - Normale</option>
+                  <option [ngValue]="4">P4 - Basse</option>
+                  <option [ngValue]="5">P5 - Très basse</option>
+                </select>
+                <span class="badge priority" [ngClass]="'p' + t.priority">{{ priorityLabel(t.priority) }}</span>
+              </div>
+              <div class="due-editor">
+                <input
+                  class="editor-input"
+                  type="date"
+                  [value]="t.dueDate ?? ''"
+                  (change)="changeDueDate(t.id, $event)"
+                />
+                <span class="badge due" *ngIf="t.dueDate" [ngClass]="dueClass(t.dueDate)">
+                  {{ dueLabel(t.dueDate) }}
+                </span>
+              </div>
             </div>
-            <p class="desc" *ngIf="t.description">{{ t.description }}</p>
+            <textarea
+              class="desc editable editor-input"
+              [value]="t.description || ''"
+              placeholder="Ajouter une description"
+              (change)="changeDescription(t.id, $event)"
+            ></textarea>
           </div>
           <button class="del" (click)="del(t.id)" [attr.aria-label]="'Supprimer ' + t.title">Supprimer</button>
         </li>

--- a/todo-ngrx/src/app/tasks/tasks-page.component.scss
+++ b/todo-ngrx/src/app/tasks/tasks-page.component.scss
@@ -119,18 +119,55 @@ textarea {
   color: var(--text-strong);
 }
 
-.list li .title.editable {
+.list li .editor-input {
   border: none;
   background: rgba(255, 255, 255, 0.55);
   padding: 10px 12px;
   border-radius: 12px;
   transition: box-shadow 0.15s ease, background 0.15s ease;
+  font: inherit;
+  color: inherit;
 }
 
-.list li .title.editable:focus {
+.list li .editor-input:focus {
   outline: none;
   background: #fff;
   box-shadow: 0 0 0 4px color-mix(in srgb, var(--brand) 28%, transparent);
+}
+
+.list li .meta-line {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+}
+
+.list li .meta-line.editors {
+  align-items: stretch;
+  gap: 16px;
+}
+
+.list li .priority-select {
+  min-width: 180px;
+}
+
+.list li .due-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 180px;
+}
+
+.list li .priority-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 200px;
+}
+
+.list li .desc.editable {
+  min-height: 90px;
+  resize: vertical;
 }
 
 .list li.done {

--- a/todo-ngrx/src/app/tasks/tasks-page.component.ts
+++ b/todo-ngrx/src/app/tasks/tasks-page.component.ts
@@ -47,6 +47,24 @@ export class TasksPageComponent {
   del(id: string)    { this.store.dispatch(A.removeTask({ id })); }
   upd(id: string, changes: any) { this.store.dispatch(A.updateTask({ id, changes })); }
 
+  changePriority(id: string, event: Event) {
+    const value = Number((event.target as HTMLSelectElement).value);
+    if (value >= 1 && value <= 5) {
+      this.upd(id, { priority: value as 1 | 2 | 3 | 4 | 5 });
+    }
+  }
+
+  changeDueDate(id: string, event: Event) {
+    const value = (event.target as HTMLInputElement).value;
+    this.upd(id, { dueDate: value || undefined });
+  }
+
+  changeDescription(id: string, event: Event) {
+    const raw = (event.target as HTMLTextAreaElement).value;
+    const trimmed = raw.trim();
+    this.upd(id, { description: trimmed ? raw : undefined });
+  }
+
   toggleDoneVisibility() { this.showDone = !this.showDone; }
 
   trackByTaskId(_: number, task: { id: string }) { return task.id; }


### PR DESCRIPTION
## Summary
- allow updating task priority, due date and description directly from the list view
- add component helpers and styling to support the new inline editors

## Testing
- npm run test -- --watch=false *(fails: No binary for Chrome browser on this platform)*

------
https://chatgpt.com/codex/tasks/task_b_68dba1e158848324b4bb07e78429ceaf