### PR TITLE
Fix task priority dropdown binding

### DIFF
--- a/todo-ngrx/src/app/tasks/tasks-page.component.html
+++ b/todo-ngrx/src/app/tasks/tasks-page.component.html
@@ -61,11 +61,11 @@
                   [value]="t.priority"
                   (change)="changePriority(t.id, $event)"
                 >
-                  <option [ngValue]="1">P1 - Critique</option>
-                  <option [ngValue]="2">P2 - Haute</option>
-                  <option [ngValue]="3">P3 - Normale</option>
-                  <option [ngValue]="4">P4 - Basse</option>
-                  <option [ngValue]="5">P5 - Très basse</option>
+                  <option value="1">P1 - Critique</option>
+                  <option value="2">P2 - Haute</option>
+                  <option value="3">P3 - Normale</option>
+                  <option value="4">P4 - Basse</option>
+                  <option value="5">P5 - Très basse</option>
                 </select>
                 <span class="badge priority" [ngClass]="'p' + t.priority">{{ priorityLabel(t.priority) }}</span>
               </div>

--- a/todo-ngrx/src/app/tasks/tasks-page.component.ts
+++ b/todo-ngrx/src/app/tasks/tasks-page.component.ts
@@ -48,7 +48,9 @@ export class TasksPageComponent {
   upd(id: string, changes: any) { this.store.dispatch(A.updateTask({ id, changes })); }
 
   changePriority(id: string, event: Event) {
-    const value = Number((event.target as HTMLSelectElement).value);
+    const target = event.target as HTMLSelectElement | null;
+    if (!target) return;
+    const value = Number.parseInt(target.value, 10);
     if (value >= 1 && value <= 5) {
       this.upd(id, { priority: value as 1 | 2 | 3 | 4 | 5 });
     }


### PR DESCRIPTION
## Summary
- ensure the in-list priority dropdown uses plain option values so changes propagate
- harden the change handler by validating the target element and parsing the selected value before dispatching the update

## Testing
- npm test -- --watch=false *(fails: Chrome browser not available in container)*

------
https://chatgpt.com/codex/tasks/task_b_68dba5580018832492492a645417051f